### PR TITLE
Update with more itertools

### DIFF
--- a/src/itercheat/itercheat.html
+++ b/src/itercheat/itercheat.html
@@ -101,7 +101,7 @@ table.summary tr.tag-unstable {
     <thead>
         <tr>
             <th>Lib</td>
-            <th>Method</th>
+            <th>Function</th>
             <th colspan="2">Input</th>
             <th>Output</th>
         </tr>
@@ -142,6 +142,12 @@ table.summary tr.tag-unstable {
             <td data-doc-link="http://doc.rust-lang.org/std/iter/fn.repeat.html">repeat</td>
             <td colspan="2">\(a\)</td>
             <td>\(\{a, a, \ldots\}\)</td>
+        </tr>
+        <tr>
+            <td>IT</td>
+            <td data-doc-link="http://bluss.github.io/rust-itertools/doc/itertools/struct.RepeatCall.html">RepeatCall::new</td>
+            <td colspan="2">\(f: () \rightarrow T\)</td>
+            <td>\(\{f(), f(), \ldots\}\)</td>
         </tr>
     </tbody>
     </table>

--- a/src/itercheat/itercheat.html
+++ b/src/itercheat/itercheat.html
@@ -730,6 +730,21 @@ table.summary tr.tag-unstable {
         </tr>
 
         <tr>
+            <td>IT</td>
+            <td>join</td>
+            <td>\(\{a_0, a_1, \ldots\, a_{n-1}\}\),</td>
+            <td>\(sep: \text{&amp;str}\)</td>
+            <td>\(
+                \begin{array}{ll}
+                d(a_0) \circ sep \circ d(a_1) \circ \ldots \circ sep \circ d(a_{n-1}) \text { wh.}\\~~
+                d \text{ is Display::fmt, } \circ \text{ is string concatenation} \\
+                \end{array}
+                \)
+            </td>
+        </tr>
+
+
+        <tr>
             <td rowspan="3">Std</td>
             <td rowspan="3">max</td>
             <td colspan="2">\(\{a_0, a_1, a_2, \ldots\}\)</td>


### PR DESCRIPTION
.join() and RepeatCall

There is more: iproduct!(), iterools::partition,  PutBack, Zip, but I don't know where they fit in.