### PR TITLE
Some fixes for itertools

### DIFF
--- a/src/itercheat/itercheat.html
+++ b/src/itercheat/itercheat.html
@@ -1493,7 +1493,7 @@ table.summary .flex-cell {
         </tr>
 
         <tr>
-            <td>Std</td>
+            <td>IT</td>
             <td>peeking_take_while</td>
             <td>Like <code link>take_while_ref</code>, but works on peekable iterators rather than cloneable ones.</td>
         </tr>

--- a/src/itercheat/itercheat.html
+++ b/src/itercheat/itercheat.html
@@ -260,7 +260,7 @@ table.summary .flex-cell {
             <td>\(
                 \{
                     \{a_0, \ldots, a_{m-1}\},
-                    \{a_n, \ldots, a_{2m-1}\},
+                    \{a_m, \ldots, a_{2m-1}\},
                     \ldots
                 \}
             \)</td>

--- a/src/itercheat/itercheat.html
+++ b/src/itercheat/itercheat.html
@@ -670,23 +670,6 @@ table.summary .flex-cell {
         </tr>
 
         <tr>
-            <td rowspan="3">IT</td>
-            <td rowspan="3">slice</td>
-            <td rowspan="2">\(\{a_0, \ldots, a_i, \ldots, a_j, \ldots\}\),</td>
-            <td>\(..j\)</td>
-            <td>\(\{a_0, \ldots, a_i, \ldots, a_{j-1}\}\)</td>
-        </tr>
-        <tr>
-            <td>\(i..\)</td>
-            <td>\(\{a_i, \ldots, a_{j-1}, \ldots\}\)</td>
-        </tr>
-        <tr>
-            <td>\(\{a_0, \ldots, a_i, \ldots, \underline{a_j, \ldots}\}\),</td>
-            <td>\(i..j\)</td>
-            <td>\(\{a_i, \ldots, a_{j-1}\}\)</td>
-        </tr>
-
-        <tr>
             <td>IT</td>
             <td>sorted</td>
             <td colspan="2">\(\{a_0, \ldots\}\)</td>

--- a/src/itercheat/itercheat.html
+++ b/src/itercheat/itercheat.html
@@ -439,24 +439,6 @@ table.summary .flex-cell {
             <td>\(g : \text{&amp;}T \rightarrow G\)</td>
             <td>\(
                 \{
-                    (g_0, [a_0, \ldots, a_{i-1}]),\\~~
-                    (g_1, [a_i, \ldots, a_{j-1}]),\\~~
-                    (g_2, [a_j, \ldots, a_{k-1}]),
-                    \ldots
-                \}
-            \)</td>
-        </tr>
-
-        <tr>
-            <td>IT</td>
-            <td>group_by_lazy</td>
-            <td>\(\{\underbrace{a_0, \ldots, a_{i-1}}_{g(a_x) = g_0},
-                \underbrace{a_i, \ldots, a_{j-1}}_{g(a_y) = g_1 \ne g_0},
-                \underbrace{a_j, \ldots, a_{k-1}}_{g(a_z) = g_2 \ne g_1},
-                \ldots\}\),</td>
-            <td>\(g : \text{&amp;}T \rightarrow G\)</td>
-            <td>\(
-                \{
                     (g_0, \{a_0, \ldots, a_{i-1}\}),\\~~
                     (g_1, \{a_i, \ldots, a_{j-1}\}),\\~~
                     (g_2, \{a_j, \ldots, a_{k-1}\}),
@@ -585,31 +567,6 @@ table.summary .flex-cell {
                 a_0.\text{map}(f),
                 \ldots
             \} : \{\text{Ok}(U) ~|~ \text{Err}(E)\}\)</td>
-        </tr>
-
-        <tr>
-            <td>IT</td>
-            <td>mend_slices</td>
-            <td colspan="2">
-                \(
-                    \{
-                        \text{&amp;}[x_0, \ldots, x_{i-1}], \text{&amp;}[x_i, \ldots, x_{n-1}],\\~~
-                        \text{&amp;}[y_0, \ldots, y_{m-1}],\\~~
-                        \text{&amp;}[z_0, \ldots, z_{l-1}],
-                        \ldots
-                    \}
-                \)
-            </td>
-            <td>
-                \(
-                    \{
-                        \text{&amp;}[x_0, \ldots, x_{i-1}, x_i, \ldots, x_{n-1}],\\~~
-                        \text{&amp;}[y_0, \ldots, y_{m-1}],\\~~
-                        \text{&amp;}[z_0, \ldots, z_{l-1}],
-                        \ldots
-                    \}
-                \)
-            </td>
         </tr>
 
         <tr>
@@ -1529,18 +1486,6 @@ table.summary .flex-cell {
             <td>Std</td>
             <td>inspect</td>
             <td>Calls a closure for each element in a sequence, without modifying the sequence in any way.</td>
-        </tr>
-
-        <tr>
-            <td>IT</td>
-            <td>into_rc</td>
-            <td>Moves the sequence into a <code>Rc&lt;RefCell&lt;_>></code>, allowing access to the iterator to be shared.</td>
-        </tr>
-
-        <tr>
-            <td>IT</td>
-            <td>is_empty_hint</td>
-            <td>Indicates whether or not the sequence is empty, and how sure of this it is.  The answer is based on the result of <code>Iterator::size_hint</code>.  Assuming that <code>size_hint</code> is accurate, \(\text{is_empty_hint}\) will return \(\text{Some}(\text{true}|\text{false})\) if it can determine that the sequence is empty or not-empty, \(\text{None}\) otherwise.</td>
         </tr>
 
         <tr>

--- a/src/itercheat/itercheat.html
+++ b/src/itercheat/itercheat.html
@@ -1312,8 +1312,8 @@ table.summary .flex-cell {
             <td>\(\text{None} \text{ wh. } n < m\)</td>
         </tr>
         <tr>
-            <td>\(\text{&amp;mut }\{a_0, \ldots, a_{m-1}, a_{m}, \ldots\}\)</td>
-            <td>\(\text{Some}((a_0, \ldots, a_{n-1}))\)</td>
+            <td>\(\text{&amp;mut }\{a_0, \ldots, a_{m-1}, \underline{a_{m}, \ldots}\}\)</td>
+            <td>\(\text{Some}((a_0, \ldots, a_{m-1}))\)</td>
         </tr>
 
         <tr>

--- a/src/itercheat/itercheat.html
+++ b/src/itercheat/itercheat.html
@@ -938,6 +938,22 @@ table.summary .flex-cell {
 
         <tr>
             <td rowspan="2">Std</td>
+            <td rowspan="2">all_equal</td>
+            <td>\(\text{&amp;mut }\{a_0, \ldots, a_{i-1}, a_i, \underline{\ldots}\}\)</td>
+            <td rowspan="2"></td>
+	    <td>\((a_0 = a_1) \land \ldots \land (a_{i-1} = a_{i}) \text{ wh. } i \text{ is first wh. } a_{i-1} \neq a_i\)</td>
+        </tr>
+        <tr>
+            <td>\(\text{&amp;mut }\{a_0\}\)</td>
+            <td>\(\text{true}\)</td>
+        </tr>
+        <tr>
+            <td>\(\text{&amp;mut }\{\}\)</td>
+            <td>\(\text{true}\)</td>
+        </tr>
+
+        <tr>
+            <td rowspan="2">Std</td>
             <td rowspan="2">any</td>
             <td>\(\text{&amp;mut }\{a_0, \ldots, a_{i-1}, a_i, \underline{\ldots}\}\)</td>
             <td rowspan="2">\(p:T \rightarrow \text{bool}\)</td>

--- a/src/itercheat/itercheat.html
+++ b/src/itercheat/itercheat.html
@@ -956,19 +956,6 @@ table.summary .flex-cell {
         </tr>
 
         <tr>
-            <td rowspan="2">IT</td>
-            <td rowspan="2">dropn</td>
-            <td>\(\text{&amp;mut }\{\underbrace{a_0, \ldots, a_{i-1}}_{\text{consumed}}, \underline{a_i, \ldots}\}\)</td>
-            <td>\(i \text{ wh. } i \le n\)</td>
-            <td>\(i\)</td>
-        </tr>
-        <tr>
-            <td>\(\text{&amp;mut }\{\underbrace{a_0, \ldots, a_{n-1}}_{\text{consumed}}\}\)</td>
-            <td>\(i \text{ wh. } i \gt n\)</td>
-            <td>\(n\)</td>
-        </tr>
-
-        <tr>
             <td>Std</td>
             <td>find</td>
             <td>\(\text{&amp;mut }\{a_0, \ldots, a_i, \underline{\ldots}\}\),</td>

--- a/src/itercheat/itercheat_tests.rs
+++ b/src/itercheat/itercheat_tests.rs
@@ -30,8 +30,9 @@ fn main() {
     }
 
     {
-        let a = vec![String::from("a"), String::from("a")];
-        assert_eq!(a.into_iter().minmax(), MinMaxResult::OneElement(String::from("a")));
+        let s = String::from;
+        let a = vec![s("c"), s("a")];
+        assert_eq!(a.into_iter().minmax(), MinMaxResult::MinMax(s("a"), s("c")));
     }
 
     println!("Ok.");


### PR DESCRIPTION
I noticed this was up to date, that's delightful. Here's a few more fixes, removing a few things that don't exist in itertools anymore and fixing just a few details. Only *addition* is the method `.all_equal()`.